### PR TITLE
Automatically tag package as a dev package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "coding-standards",
         "php-cs-fixer",
         "code-quality",
-        "psr-12"
+        "psr-12",
+        "dev",
     ]
 }

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,6 @@
         "php-cs-fixer",
         "code-quality",
         "psr-12",
-        "dev",
+        "dev"
     ]
 }


### PR DESCRIPTION
Adding a `dev` keyword means the package will automatically be put into dev dependencies.